### PR TITLE
2.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,44 @@
 # Changelog
 
+## [2.0.0] 06-06-2025
+
+### BREAKING
+
+#### Renames
+
+-   `RequireAtLeastOne` -> `Require`
+-   `ExcludeIndexSignature` -> `NotIndexable`
+-   `HasToString` -> `Stringifyable`
+-   `AnyFunction` -> `AnyFn`
+-   `MaybeFunction` -> `MaybeFn`
+-   `TypedResultFunction` -> `TypedFn`
+-   `HomogenousFunction` -> `LinearMapperFn`
+-   `HeterogenousFunction` -> `MapperFn`
+-   `AsyncFunction` -> `AsyncFn`
+-   `TypedAsyncFunction` -> `AsyncFn<T>`
+-   `SimpleVoidFunction` -> `VoidFn`
+-   `AnyVoidFunction` -> `VoidFn`
+-   `TypedVoidFunction` -> `VoidFn<T>`
+-   `TimeoutFunction` -> `TimeoutFn`
+-   `ClearTimeoutFunction` -> `ClearTimeoutFn`
+-   `MethodDecorator` -> `Decorator`
+-   `SingleNumberMap` -> `SingleMap<number>`
+-   `DoubleNumberMap` -> `DoubleMap<number>`
+-   `SVGAttribute` -> `SVGAttr`
+
+#### Removed
+
+-   `AnyObject` in favor of `object` (just deactivate the corresponding ESLint Rule)
+-   `CartesianProduct` for being too niche.
+
+### Added
+
+-   `Jsonfyable<T>` to define objects that can be safely converted to a JSON string.
+
+### Fixed
+
+-   Incorrect function to check of `HasValue<T>`
+
 ## [1.12.0] 06-04-2025
 
 ### Added

--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,6 +1,6 @@
 The MIT License (MIT)
 
-Copyright 2023 Torathion
+Copyright 2025 Torathion
 
 Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the “Software”), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
 

--- a/README.md
+++ b/README.md
@@ -14,10 +14,11 @@ Become the star of TypeScript with TypeStar! TypeStar is a vast collection of he
 
 This type library includes:
 
+-   A lot of types of Element and SVG handling
 -   A fully typed interface representing a `package.json` file
 -   A fully typed extension of `process` for electron that only includes the properties.
 -   A whole bunch of object and promise helper types.
 
 ---
 
-© Torathion 2024
+© Torathion 2025

--- a/index.d.ts
+++ b/index.d.ts
@@ -74,9 +74,9 @@ declare module 'typestar' {
         [P in keyof T]: string
     }
     /**
-     *  Requires at least one key in `Keys` to be present in `T`.
+     *  Helper type describing a given object with given keys to be present.
      */
-    export type RequireAtLeastOne<T, Keys extends keyof T = keyof T> = Partial<T> & { [K in Keys]-?: Pick<T, K> }[Keys]
+    export type Required<T, Keys extends keyof T = keyof T> = Partial<T> & { [K in Keys]-?: Pick<T, K> }[Keys]
     /**
      *  Converts a tuple type to a union of its element types.
      */
@@ -115,7 +115,7 @@ declare module 'typestar' {
      *
      *  @template T - The type to filter.
      */
-    export type ExcludeIndexSignature<T> = {
+    export type NotIndexable<T> = {
         [P in keyof T as string extends P ? never : number extends P ? never : P]: T[P]
     }
     /**
@@ -247,14 +247,18 @@ declare module 'typestar' {
         [K in keyof T]: T[K] extends V ? K : never
     }[keyof T]
     /**
-     *  Extends a type to ensure it includes a `toString` method that is used for internal string conversion.
+     *  Helper type describing an object that can be safely converted to a JSON string.
      */
-    export type HasToString<T> = T & { toString: (...args: any[]) => string }
+    export type Jsonfyable<T> = T & { toJSON: (...args: any[]) => string }
+    /**
+     *  Helper type describing an object that can be safely stringified.
+     */
+    export type Stringifyable<T> = T & { toString: (...args: any[]) => string }
 
     /**
      * Extends a type to ensure it includes a `valueOf` method that is often used for internal javascript processes.
      */
-    export type HasValue<T> = T & { value: (...args: any[]) => number }
+    export type HasValue<T> = T & { valueOf: (...args: any[]) => number }
     /*
      *			ARRAY
      */
@@ -351,43 +355,31 @@ declare module 'typestar' {
     /**
      *  Type describing an arbitrary function.
      */
-    export type AnyFunction = (...args: any[]) => any
+    export type AnyFn = (...args: any[]) => any
     /**
      *  Type describing an argument that can easy be a static value or the result of a dynamically calculated function.
      */
-    export type MaybeFunction<T> = T | (() => T)
+    export type MaybeFn<T> = T | (() => T)
     /**
      *  Type describing a function with arbitrary arguments but with a defined result type.
      */
-    export type TypedResultFunction<T> = (...args: any[]) => T
+    export type TypedFn<T> = (...args: any[]) => T
     /**
      * 	Type describing a function with arbitrary arguments and result of the same defined type.
      */
-    export type HomogenousFunction<T> = (...args: T[]) => T
+    export type LinearMapperFn<T> = (...args: T[]) => T
     /**
      * 	Type describing a function with arbitrary arguments of one type and a result of another type.
      */
-    export type HeterogenousFunction<A, R> = (...args: A[]) => R
+    export type MapperFn<R, A = any> = (...args: A[]) => R
     /**
      * 	Type describing a function that runs asynchronously.
      */
-    export type AsyncFunction = (...args: any[]) => Promise<unknown>
-    /**
-     *  Type describing a function that runs asynchronously with arbitrary arguments and with a typed return value.
-     */
-    export type TypedAsyncFunction<T> = (...args: any[]) => Promise<T>
+    export type AsyncFn<R = unknown, A = any> = (...args: A[]) => Promise<R>
     /**
      *  Type describing a function with no return value an no arguments.
      */
-    export type SimpleVoidFunction = () => void
-    /**
-     *  Type describing a function with arbitrary arguments, but with no return value.
-     */
-    export type AnyVoidFunction = (...args: any[]) => void
-    /**
-     *  Type describing a function with arbitrary typed arguments, but with not return value.
-     */
-    export type TypedVoidFunction<T> = (...args: T[]) => void
+    export type VoidFn<T = any> = (...args: any[]) => T
     /**
      *  Type specifying the arguments of a function.
      */
@@ -395,15 +387,15 @@ declare module 'typestar' {
     /**
      *  Type describing the function inside a `setTimeout` function.
      */
-    export type TimeoutFunction = (handler: TimerHandler, timeout?: number | undefined, ...args: any[]) => number
+    export type TimeoutFn = (handler: TimerHandler, timeout?: number | undefined, ...args: any[]) => number
     /**
      *  Type describing a function that clears a timeout.
      */
-    export type ClearTimeoutFunction = (timeoutId: string | number | Timeout | undefined) => void
+    export type ClearTimeoutFn = (timeoutId: string | number | Timeout | undefined) => void
     /**
      *  Type describing the function inside a `setInterval` function.
      */
-    export type IntervalFunction = (handler: TimerHandler, timeout?: number, ...args: any[]) => number
+    export type IntervalFn = (handler: TimerHandler, timeout?: number, ...args: any[]) => number
     /**
      *   Type describing a variable to store a timeout inside. (i.e. the timeout id.)
      */
@@ -415,15 +407,15 @@ declare module 'typestar' {
     /**
      *  Type describing a function that acts as a decorator to a class method.
      */
-    export type MethodDecorator = (target: unknown, propertyKey: string, descriptor: PropertyDescriptor) => void
+    export type Decorator = (target: unknown, propertyKey: string, descriptor: PropertyDescriptor) => void
     /**
-     *  Represents a function that maps a single number to another number.
+     *  Represents a function that maps a single argument to another value.
      */
-    export type SingleNumberMap = (x: number) => number
+    export type SingleMap<T> = (x: T) => T
     /**
-     *  Represents a function that maps two numbers to another number.
+     *  Represents a function that maps two arguments to a value.
      */
-    export type DoubleNumberMap = (x: number, y: number) => number
+    export type DoubleMap = (x: T, y: T) => T
     /*
      *			PROMISE
      */
@@ -531,7 +523,7 @@ declare module 'typestar' {
     /**
      * Represents an attribute value for an SVG element, which can be a string, number, or null.
      */
-    export type SVGAttribute = null | number | string
+    export type SVGAttr = null | number | string
     /**
      * Represents a dictionary of properties where keys are strings
      * and values conform to the `ElementValue` type.

--- a/index.d.ts
+++ b/index.d.ts
@@ -411,7 +411,7 @@ declare module 'typestar' {
     /**
      *  Represents a function that maps two arguments to a value.
      */
-    export type DoubleMap = (x: T, y: T) => T
+    export type DoubleMap<T> = (x: T, y: T) => T
     /*
      *			PROMISE
      */

--- a/index.d.ts
+++ b/index.d.ts
@@ -345,10 +345,6 @@ declare module 'typestar' {
             ? [[H1, H2], ...Zip<R1, R2>]
             : []
         : []
-    /**
-     *  Computes the Cartesian product of two union types.
-     */
-    export type CartesianProduct<U1, U2> = U1 extends any ? (U2 extends any ? [U1, U2] : never) : never
     /*
      *			FUNCTION
      */

--- a/index.d.ts
+++ b/index.d.ts
@@ -132,10 +132,6 @@ declare module 'typestar' {
      *			OBJECTS
      */
     /**
-     * 	Type describing any object. The sole purpose of this type is to get rid of type "any" warnings.
-     */
-    export type AnyObject = Record<any, any>
-    /**
      *  Type describing a lookup table like structure.
      */
     export type Table<T> = Record<string, T>
@@ -146,15 +142,15 @@ declare module 'typestar' {
     /**
      *  Helper type extracting all types of an interface as a union.
      */
-    export type Values<T extends AnyObject> = T[keyof T]
+    export type Values<T extends object> = T[keyof T]
     /**
      * 	Type specifying an entry from `Object.property.entries`.
      */
-    export type Entry<T extends AnyObject> = [keyof T, Values<T>]
+    export type Entry<T extends object> = [keyof T, Values<T>]
     /**
      * 	Type specifying all entries from `Object.property.entries`
      */
-    export type Entries<T extends AnyObject> = Entry<T>[]
+    export type Entries<T extends object> = Entry<T>[]
     /**
      * 	Type describing a dictionary data structure like object.
      */

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
     "name": "typestar",
     "version": "1.12.0",
-    "description": "Become the star of typescript with these essential types to boost your typescript coding!",
+    "description": "Type library to reduce unreadable and long type definitions",
     "types": "index.d.ts",
     "keywords": [
         "typescript",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "typestar",
-    "version": "1.12.0",
+    "version": "2.0.0",
     "description": "Type library to reduce unreadable and long type definitions",
     "types": "index.d.ts",
     "keywords": [

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -35,7 +35,7 @@
         "lib": ["dom", "ESNext", "WebWorker", "ScriptHost"]
     },
     "exclude": ["**/node_modules/**", "typings", "dist", "test", "coverage"],
-    "include": ["patches/**/*.d.ts", "index.d.ts"],
+    "include": ["patches/**/*.d.ts", "./index.d.ts"],
     "ts-node": {
         "compilerOptions": {
             "module": "umd"


### PR DESCRIPTION
This update aims to overhaul a lot of types and shorten their names. I've come to notice that I more and more disliked using the types from this package, because the names were simply way too long. That is rather ironical, because the goal of this package should be to REDUCE the code for type definitions. I also was able to fuse some types due to default generics.

Every is listed in the README.