### PR TITLE
release: 2.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [2.1.0] 06-10-2025
+
+### Added
+
+-   Inverted change of removing `AnyObject`, now featuring a more configurable version called `Obj`
+
 ## [2.0.0] 06-06-2025
 
 ### BREAKING

--- a/index.d.ts
+++ b/index.d.ts
@@ -136,6 +136,10 @@ declare module 'typestar' {
      */
     export type Table<T> = Record<string, T>
     /**
+     *  Type describing any object that can be typed. Used for generic object algorithms.
+     */
+    export type Obj<K = any, V = any> = Record<K, V>
+    /**
      * 	Type describing any type that can be used as an index key of an object.
      */
     export type IndexKey = string | symbol | number

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "typestar",
-    "version": "2.0.0",
+    "version": "2.1.0",
     "description": "Type library to reduce unreadable and long type definitions",
     "types": "index.d.ts",
     "keywords": [


### PR DESCRIPTION
While migrating, I realized removing `AnyObject` was a horrible idea.  So I quickly fixed it while also making it more configurable.